### PR TITLE
Add offline support with service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,5 +196,12 @@
 
     <!-- External JavaScript -->
     <script type="module" src="scripts.js"></script>
+    <script>
+        if ("serviceWorker" in navigator) {
+            window.addEventListener("load", () => {
+                navigator.serviceWorker.register("./service-worker.js");
+            });
+        }
+    </script>
 </body>
 </html>

--- a/scripts.js
+++ b/scripts.js
@@ -3,7 +3,7 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.3/firebase-app.js";
 import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.12.3/firebase-analytics.js";
-import { getFirestore, collection, addDoc, getDocs, updateDoc, deleteDoc, doc, serverTimestamp, writeBatch } from "https://www.gstatic.com/firebasejs/10.12.3/firebase-firestore.js";
+import { enableIndexedDbPersistence, getFirestore, collection, addDoc, getDocs, updateDoc, deleteDoc, doc, serverTimestamp, writeBatch } from "https://www.gstatic.com/firebasejs/10.12.3/firebase-firestore.js";
 import { 
     getAuth, 
     onAuthStateChanged, 
@@ -213,6 +213,9 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const analytics = getAnalytics(app);
 const db = getFirestore(app);
+enableIndexedDbPersistence(db).catch(e => {
+    console.warn("Offline persistence not available", e);
+});
 const auth = getAuth(app);
 
 // Initialize AlarmService

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,33 @@
+const CACHE_NAME = 'epictaskquest-cache-v1';
+const OFFLINE_URLS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/scripts.js',
+  '/hashtag-hierarchy.css',
+  '/hashtag-hierarchy.js',
+  '/js/AlarmService.js',
+  '/js/AudioService.js',
+  '/alert.mp3',
+  '/trophy.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- support offline usage with a new service worker
- enable Firestore offline persistence

## Testing
- `npm test` *(fails: package.json not found)*