### PR TITLE
Support multiple custom tag styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,13 +183,9 @@
                 <input type="text" id="parentToggleEasterEgg" placeholder="Easter egg (emoji)">
             </div>
             <div class="hashtag-preset">
-                <h4>Custom Tag Style</h4>
-                <input type="text" id="customTag" placeholder="Enter hashtag (e.g., #0)">
-                <input type="number" id="customFontSize" placeholder="Font size (px)">
-                <input type="text" id="customFontFamily" placeholder="Font family">
-                <input type="color" id="customHoverColor">
-                <input type="text" id="customEasterEgg" placeholder="Easter egg (emoji)">
-                <button class="reset-button" id="applyCustom">Apply</button>
+                <h4>Custom Tag Styles</h4>
+                <div id="customTagsContainer"></div>
+                <button class="reset-button" id="addCustomTag">Add Custom Tag</button>
             </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -2316,6 +2316,18 @@ input[type="number"].custom-points::-webkit-outer-spin-button {
     cursor: pointer;
 }
 
+.custom-tag-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.custom-tag-row input,
+.custom-tag-row button {
+    flex: 1 1 100px;
+}
+
 /* Mobile-specific adjustments */
 @media (max-width: 768px) {
     .hashtag-config-panel {


### PR DESCRIPTION
## Summary
- allow multiple custom tag styles
- style UI rows for custom tag configs
- sync and persist multiple custom tag settings

## Testing
- `node -e "require('./scripts.js')"` *(fails: network import disallowed)*

------
https://chatgpt.com/codex/tasks/task_b_684947eb6bd083249382b9398d04bbb1