### PR TITLE
Improve contrast for task controls

### DIFF
--- a/style.css
+++ b/style.css
@@ -712,7 +712,7 @@ body {
 .task-actions button {
     background: none;
     border: none;
-    color: var(--blue-7); /* Replace #1e90ff with our brightest blue */
+    color: var(--bright-text); /* Improved contrast */
     cursor: pointer;
     font-size: 1.3rem;
     transition: color var(--transition-speed) ease, transform var(--transition-speed) ease;
@@ -1681,7 +1681,7 @@ input[type="number"].custom-points::-webkit-outer-spin-button,
 #customPoints::-webkit-outer-spin-button {
     height: 40px;
     opacity: 1;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.3); /* Improved contrast */
     border-radius: 4px;
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- update task action icon color for better contrast
- lighten number input spinner background

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_684def4f9f28832489cbe5bb9d0784b5