### PR TITLE
Fix alarm text display

### DIFF
--- a/js/AlarmService.js
+++ b/js/AlarmService.js
@@ -14,7 +14,7 @@ export class AlarmService {
 
     parseAlarmPattern(text) {
         const standardMatch = text.match(/!(\d{2})(\d{2})(\d{2})(\d{2})/);
-        const simpleMatch = text.match(/!(\d{2})(\d{2})/);
+        const simpleMatch = text.match(/!(\d{2}):?(\d{2})/);
 
         if (standardMatch) {
             const [_, day, month, hours, minutes] = standardMatch;
@@ -76,7 +76,7 @@ export class AlarmService {
 
         if (delay > 0) {
             const timeoutId = setTimeout(() => {
-                this.triggerAlarm(taskId, taskText);
+                this.triggerAlarm(taskText);
             }, delay);
 
             this.alarms.set(taskId, { timeoutId, alarmTime });


### PR DESCRIPTION
## Summary
- show task name instead of task ID when alarm rings
- parse alarms with optional colon between hours and minutes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68527cb579488324a6123fae52888086