### PR TITLE
Fix wishlist filter opens #0buy tab

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1771,7 +1771,15 @@ window.addEventListener('click', (event) => {
 wishlistFilter.addEventListener('click', () => {
     currentFilter = currentFilter === 'wishlist' ? 'all' : 'wishlist';
     wishlistFilter.classList.toggle('active', currentFilter === 'wishlist');
-    
+
+    // When switching to wishlist view, close all open tabs and open the #0buy tab
+    if (currentFilter === 'wishlist') {
+        openToggles.clear();
+        openToggles.add('#0buy');
+    } else {
+        openToggles.clear();
+    }
+
     // Refresh the task list with current search term
     filterTasks(taskSearchInput.value);
 });


### PR DESCRIPTION
## Summary
- update wishlist filter to collapse all groups and expand `#0buy`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6866361a843c83248fe2a147060becfd